### PR TITLE
fix(REQ-042): robust format selection for SABR streaming

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ bun.lock
 # Debug cache
 debug-cache/
 .claude/settings.local.json
+docs/logfiles/

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -113,6 +113,22 @@ Anforderungs-ID verweisen. Einmal gesetzte IDs dürfen nicht mehr angepasst werd
 | REQ-032 | **Debug-Cache für Downloads:** Im Debug-Modus wird der yt-dlp Download parallel in eine lokale Datei geschrieben (Video/Audio separat), um die Download-Funktion unabhängig vom RTP-Pfad prüfen zu können. | Should |
 | REQ-033 | **`/vid-debug-cache` Command:** Zeigt alle gecachten Download-Dateien (Video/Audio) mit Größe und Zeitstempel an. Ermöglicht Nutzer, heruntergeladene Dateien zu inspizieren und vom Host aus (via Docker-Volume `./debug-cache/`) herunterzuladen. Nur verfügbar wenn Debug Output aktiv ist. | Should |
 
+## REQ-042 — Robuste Format-Selektion bei SABR-Streaming
+
+**Priorität:** Must
+**Status:** Implementiert
+
+Das Plugin MUSS beim YouTube-Download robust gegen SABR-Streaming (Server-Adaptive Bitrate) sein:
+
+- REQ-042-A: HLS-Sub-Format-IDs (Format `NNN-N`, z.B. `301-0`) müssen erkannt und der Locked-Format-Pfad übersprungen werden
+- REQ-042-B: Der Video-Fallback-Selektor muss neben avc1 auch vp09 und av01 Formate unterstützen
+- REQ-042-C: SABR-Manifest-URLs (manifest.googlevideo.com) müssen aus der Format-Selektion ausgeschlossen werden
+- REQ-042-D: Der Fallback `bv` (beliebiges bestes Video) muss als letzter Ausweg verfügbar sein
+
+**Hintergrund:** YouTube erzwingt SABR für bestimmte Server-IPs. Alle avc1-Formate können auf betroffenen Servern nicht per yt-dlp heruntergeladen werden. Referenz: yt-dlp/yt-dlp#12482
+
+---
+
 ## Traceability
 
 Jeder Test MUSS mit dem Format `[REQ-xxx]` auf eine oder mehrere Anforderungen

--- a/docs/conclusions/conclusions-2026-03-25-sabr-format-fix.md
+++ b/docs/conclusions/conclusions-2026-03-25-sabr-format-fix.md
@@ -1,0 +1,144 @@
+# Erkenntnisse — 25. März 2026
+
+## Session-Zusammenfassung
+
+Debugging und Fix des SABR-Streaming-Bugs: Auf dem Live-Server kord.awaysome.de wurde kein Video
+abgespielt. Ursache war eine Kombination aus YouTube SABR-Enforcement, nicht-portablen HLS-Sub-Format-IDs
+und einem zu engen Fallback-Selektor. Fix implementiert als REQ-042 auf Branch `fix/sabr-format-fallback`.
+
+---
+
+## 1. Root Cause Analyse
+
+### Hauptproblem: YouTube SABR-Streaming
+
+YouTube erzwingt für bestimmte Server-IPs und Accounts "Server-Adaptive Bitrate (SABR)"-Streaming.
+SABR-Formate erscheinen in `yt-dlp --dump-json` als valide Formate mit `url`-Feld, sind aber beim
+tatsächlichen Download nicht verfügbar.
+
+- **Fehlermeldung im Log:** `Requested format is not available. Use --list-formats`
+- **Betroffen:** Alle `avc1` (H.264) Formate auf dem Live-Server kord.awaysome.de
+- **Hinweis im Log:** `Some web_safari client https formats have been skipped as they are missing a URL. YouTube is forcing SABR streaming`
+- **Referenz:** https://github.com/yt-dlp/yt-dlp/issues/12482
+
+Das Problem tritt nur auf dem Live-Server auf, nicht lokal, weil YouTube die Server-IP als
+"server-like" einstuft und SABR erzwingt. Das lokale Docker-System hat eine andere IP und erhält
+andere (non-SABR) Formate.
+
+### Problem 2: HLS Sub-Format-IDs sind nicht portabel
+
+`resolveVideo` wählt Format-IDs mit `-N` Suffix (z.B. `301-0`). Diese IDs sind HLS-Playlist-Einträge,
+die spezifisch für die Server-Session beim `--dump-json` Call sind. Beim späteren Download mit
+`-f 301-0` ist das Format nicht mehr verfügbar — besonders wenn zwischen `resolveVideo` und
+Download Zeit vergeht oder die Server-IP wechselt.
+
+### Problem 3: Zu enger Fallback-Selektor
+
+Der bisherige Fallback `bv[vcodec^=avc1]` schlägt ebenfalls fehl, wenn der Server SABR für alle
+avc1-Formate erzwingt. Es gab keinen vp9/av01 Fallback. Da ffmpeg bereits mit `-c:v libx264`
+konfiguriert ist, kann es vp9/av01 zu H.264 re-encodieren — der fehlende Fallback war unnötig
+restriktiv.
+
+### Problem 4: Kein JS-Runtime verfügbar
+
+Im Log: `JS Challenge Providers: bun (unavailable), deno (unavailable), node (unavailable), quickjs (unavailable)`
+
+Das schränkt die Format-Verfügbarkeit ein. Die vorhandene cookies.txt gibt bereits
+Authenticated-Access (YouTube Account-Cookies), verhindert aber nicht SABR-Enforcement.
+
+---
+
+## 2. Warum lokal funktionsfähig, auf Live-Server nicht?
+
+| Aspekt | Lokal (Docker) | Live-Server kord.awaysome.de |
+|--------|---------------|------------------------------|
+| IP-Klassifikation | Private/Consumer-IP | Server-IP → YouTube klassifiziert als potenzielle Bot-Infrastruktur |
+| SABR-Enforcement | Nein | Ja — alle avc1-Formate per SABR gesperrt |
+| Format-Verfügbarkeit | avc1-Formate verfügbar | Nur vp9/av01 oder SABR-Streams |
+| JS-Runtime | Verfügbar (Bun läuft) | Nicht verfügbar im yt-dlp Kontext |
+
+---
+
+## 3. Implementierter Fix (REQ-042)
+
+Branch: `fix/sabr-format-fallback`
+
+### Neue Funktion: `isHlsSubFormatId()`
+
+Erkennt Format-IDs mit `-N` Suffix (z.B. `301-0`, `234-1`) als nicht-portable HLS-Sub-Formate.
+Diese IDs verweisen auf HLS-Playlist-Einträge, die session-spezifisch sind und nicht zuverlässig
+für einen späteren Download verwendet werden können.
+
+### Erweiterte Fallback-Kette in `buildYtDlpDownloadCmd`
+
+Bisherige Kette:
+```
+format_id → bv[vcodec^=avc1]
+```
+
+Neue Kette:
+```
+format_id (nur wenn kein HLS-Sub-ID) → bv[vcodec^=avc1] → bv[vcodec^=vp09] → bv[vcodec^=av01] → bv
+```
+
+HLS-Sub-Format-IDs werden beim Aufbau des Download-Commands übersprungen.
+
+### Angepasste Logik in `parseYtDlpOutput`
+
+Filtert beim Parsen der yt-dlp Ausgabe:
+- SABR-Manifest-URLs (URLs die `manifest.googlevideo.com` enthalten)
+- HLS-Sub-Format-IDs aus der Format-Selektion heraus
+
+### Angepasste Logik in `shouldRetryWithoutFormatId`
+
+HLS-Sub-Format-IDs lösen automatisch einen Retry ohne Format-Lock aus (entsprechend REQ-027-D).
+
+---
+
+## 4. Beobachtung: Bot joint kurz, verschwindet dann wieder
+
+Der Sharkord-Bot erstellt Transport und Producer (sichtbar im Log), aber der Nutzer sieht ihn
+nicht dauerhaft im Voice-Channel:
+
+1. `createStream()` wird erst nach erfolgreichem yt-dlp-Download aufgerufen
+2. yt-dlp schlägt fehl (SABR) → `cleanup()` wird aufgerufen
+3. `cleanup()` entfernt den Stream-Handle → Bot verlässt den Channel
+4. Nutzer sieht den Bot kurz erscheinen und wieder verschwinden
+
+Das Verhalten ist ein Symptom des yt-dlp-Fehlers, kein eigenständiger Bug. Mit dem SABR-Fix
+schlägt yt-dlp nicht mehr fehl, und der Bot bleibt im Channel.
+
+---
+
+## 5. Technische Referenzen
+
+### Relevante Dateien
+
+- `src/stream/yt-dlp.ts` — Hauptdatei des Fixes (Format-Selektion, Fallback-Kette, HLS-Sub-Erkennung)
+- `src/stream/stream-manager.ts` — Stream-Lifecycle, createStream/cleanup Reihenfolge
+- `docs/REQUIREMENTS.md` — REQ-042 (neu hinzugefügt)
+
+### Externe Referenzen
+
+- yt-dlp SABR Issue: https://github.com/yt-dlp/yt-dlp/issues/12482
+- SABR-Erklärung: YouTube Server-Adaptive Bitrate — Streaming-Protokoll das den Download-Pfad
+  serverseitig kontrolliert; nicht kompatibel mit direktem yt-dlp-Download einzelner Format-URLs
+
+### Log-Erkennungsmerkmale für SABR-Probleme
+
+```
+Some web_safari client https formats have been skipped as they are missing a URL.
+YouTube is forcing SABR streaming
+```
+
+```
+Requested format is not available. Use --list-formats
+```
+
+---
+
+## 6. Offene Punkte
+
+- REQ-042 ist auf Branch `fix/sabr-format-fallback` — Tests und Merge stehen noch aus
+- JS-Runtime-Verfügbarkeit in der Docker-Umgebung prüfen (yt-dlp nutzt JS für manche Extraktoren)
+- Langzeit-Beobachtung nach Merge: Tritt SABR weiterhin auf? Dann ggf. `--extractor-args` evaluieren

--- a/src/stream/ffmpeg.ts
+++ b/src/stream/ffmpeg.ts
@@ -158,6 +158,15 @@ export const shouldCleanupDownloadedData = (debugEnabled: boolean): boolean =>
   !debugEnabled;
 
 /**
+ * Returns true if a format ID is an HLS sub-format (e.g. "301-0", "248-1")
+ * that may not be available across different server IPs. (REQ-042)
+ */
+export const isHlsSubFormatId = (formatId: string | undefined): boolean => {
+  if (!formatId || !formatId.trim()) return false;
+  return /^\d+-\d+$/.test(formatId.trim());
+};
+
+/**
  * Decide whether a failed yt-dlp run should be retried without a strict format lock.
  * This handles videos where a previously resolved format_id later becomes unavailable.
  * (REQ-027)
@@ -168,6 +177,7 @@ export const shouldRetryWithoutFormatId = (
   formatId?: string
 ): boolean => {
   if (!formatId || !formatId.trim()) return false;
+  if (isHlsSubFormatId(formatId)) return true;  // HLS sub-formats are never reliably downloadable
   if (exitCode === null || exitCode === 0 || exitCode === 143) return false;
   if (/Requested format is not available/i.test(stderrText)) return true;
   // Some yt-dlp failures provide little/no stderr detail in container logs.
@@ -205,18 +215,18 @@ export const buildYtDlpDownloadCmd = (options: YtDlpDownloadOptions & { outputPa
   // REQ-038: Do not force mpegts when a concrete format lock is active.
   // Some locked DASH formats are regular MP4 and post-process behavior can become unstable
   // for a concurrently-read temp file.
-  if (streamType === "video" && useMpegTsOutput && !(formatId && formatId.trim())) {
+  if (streamType === "video" && useMpegTsOutput && !(formatId && formatId.trim() && !isHlsSubFormatId(formatId))) {
     cmd.push("--hls-use-mpegts");
   }
 
   // ALWAYS prefer youtubeUrl over pre-resolved CDN URL
   if (youtubeUrl) {
-    if (formatId && formatId.trim()) {
+    if (formatId && formatId.trim() && !isHlsSubFormatId(formatId)) {
       cmd.push("-f", formatId.trim(), "-o", outputPath, youtubeUrl);
     } else {
       const formatSel = streamType === "video"
-        ? "bv[vcodec^=avc1][height<=1080]/bv[vcodec^=avc1]/bv*[vcodec^=avc1]"
-        : "ba[acodec=opus]/ba[acodec=aac]/ba/ba*/bestaudio[acodec=opus]/bestaudio[acodec=aac]/bestaudio";
+        ? "bv[vcodec^=avc1][height<=1080]/bv[vcodec^=avc1]/bv*[vcodec^=avc1]/bv[vcodec^=vp09][height<=1080]/bv[vcodec^=vp09]/bv[vcodec^=av01][height<=1080]/bv[vcodec^=av01]/bv[height<=1080]/bv"
+        : "ba[acodec=opus]/ba[acodec=aac]/ba[acodec^=mp4a]/ba/ba*/bestaudio[acodec=opus]/bestaudio[acodec=aac]/bestaudio";
       cmd.push("-f", formatSel, "-o", outputPath, youtubeUrl);
     }
   } else {

--- a/src/stream/yt-dlp.ts
+++ b/src/stream/yt-dlp.ts
@@ -110,7 +110,14 @@ export const parseYtDlpOutput = (jsonString: string): ResolvedVideo => {
     };
 
     const h264Formats = formats
-      .filter((f) => isH264(f["vcodec"]) && f["url"])
+      .filter((f) => {
+        if (!isH264(f["vcodec"]) || !f["url"]) return false;
+        // Exclude HLS manifest URLs — these are SABR/adaptive streams not downloadable via yt-dlp
+        if (typeof f["url"] === "string" && f["url"].includes("manifest.googlevideo.com")) return false;
+        // Exclude formats with HLS sub-format IDs (not portable across server IPs)
+        if (typeof f["format_id"] === "string" && /^\d+-\d+$/.test(f["format_id"])) return false;
+        return true;
+      })
       .sort((a, b) => {
         const heightA = typeof a["height"] === "number" ? a["height"] : 0;
         const heightB = typeof b["height"] === "number" ? b["height"] : 0;
@@ -123,14 +130,25 @@ export const parseYtDlpOutput = (jsonString: string): ResolvedVideo => {
       return h <= 1080;
     }) || h264Formats[0];
     
-    if (videoFormat && typeof videoFormat["url"] === "string") {
+    if (h264Formats.length === 0) {
+      // No H.264 formats available (e.g. all are SABR) — clear IDs so fallback selector is used
+      streamUrl = "";
+      videoFormatId = "";
+    } else if (videoFormat && typeof videoFormat["url"] === "string") {
       streamUrl = videoFormat["url"];
       videoFormatId = String(videoFormat["format_id"] || "");
     }
-    
+
     // Find best audio-only format (AAC preferred for reliable decoding)
     const audioFormat = formats
-      .filter((f) => f["acodec"] && f["acodec"] !== "none" && (!f["vcodec"] || f["vcodec"] === "none") && f["url"])
+      .filter((f) => {
+        if (!f["acodec"] || f["acodec"] === "none") return false;
+        if (f["vcodec"] && f["vcodec"] !== "none") return false;
+        if (!f["url"]) return false;
+        // Exclude formats with HLS sub-format IDs (not portable across server IPs)
+        if (typeof f["format_id"] === "string" && /^\d+-\d+$/.test(f["format_id"])) return false;
+        return true;
+      })
       .sort((a, b) => {
         const brA = typeof a["abr"] === "number" ? a["abr"] : 0;
         const brB = typeof b["abr"] === "number" ? b["abr"] : 0;

--- a/tests/unit/sabr-format-fallback.test.ts
+++ b/tests/unit/sabr-format-fallback.test.ts
@@ -1,0 +1,251 @@
+/**
+ * Unit tests for SABR streaming and HLS sub-format ID handling.
+ *
+ * TDD: Tests cover the SABR format fallback logic introduced in REQ-042.
+ * Tests pure functions only — no binary execution required.
+ *
+ * Referenced by: REQ-042
+ */
+import { describe, it, expect } from "bun:test";
+import {
+  isHlsSubFormatId,
+  shouldRetryWithoutFormatId,
+  buildYtDlpDownloadCmd,
+} from "../../src/stream/ffmpeg";
+import { parseYtDlpOutput } from "../../src/stream/yt-dlp";
+
+// ---- isHlsSubFormatId ----
+
+describe("isHlsSubFormatId", () => {
+  it("[REQ-042] should return true for format '301-0'", () => {
+    expect(isHlsSubFormatId("301-0")).toBe(true);
+  });
+
+  it("[REQ-042] should return true for format '248-1'", () => {
+    expect(isHlsSubFormatId("248-1")).toBe(true);
+  });
+
+  it("[REQ-042] should return true for format '0-0'", () => {
+    expect(isHlsSubFormatId("0-0")).toBe(true);
+  });
+
+  it("[REQ-042] should return false for '140-drc' (suffix is not digits)", () => {
+    expect(isHlsSubFormatId("140-drc")).toBe(false);
+  });
+
+  it("[REQ-042] should return false for plain format id '301' (no suffix)", () => {
+    expect(isHlsSubFormatId("301")).toBe(false);
+  });
+
+  it("[REQ-042] should return false for format '140'", () => {
+    expect(isHlsSubFormatId("140")).toBe(false);
+  });
+
+  it("[REQ-042] should return false for format '137'", () => {
+    expect(isHlsSubFormatId("137")).toBe(false);
+  });
+
+  it("[REQ-042] should return false for empty string", () => {
+    expect(isHlsSubFormatId("")).toBe(false);
+  });
+
+  it("[REQ-042] should return false for undefined", () => {
+    expect(isHlsSubFormatId(undefined)).toBe(false);
+  });
+});
+
+// ---- shouldRetryWithoutFormatId with HLS sub-format IDs ----
+
+describe("shouldRetryWithoutFormatId", () => {
+  it("[REQ-042] should return true immediately for HLS sub-format id even with exit 1", () => {
+    expect(shouldRetryWithoutFormatId(1, "", "301-0")).toBe(true);
+  });
+
+  it("[REQ-042] should return true for HLS sub-format id even with exit 0 (never reliably downloadable)", () => {
+    expect(shouldRetryWithoutFormatId(0, "", "301-0")).toBe(true);
+  });
+
+  it("[REQ-042] should return true for normal format id when stderr says format not available", () => {
+    expect(
+      shouldRetryWithoutFormatId(1, "Requested format is not available", "140")
+    ).toBe(true);
+  });
+
+  it("[REQ-042] should return false for normal format id with exit 0 and no error", () => {
+    expect(shouldRetryWithoutFormatId(0, "", "140")).toBe(false);
+  });
+});
+
+// ---- buildYtDlpDownloadCmd — HLS sub-format IDs fall back to selector ----
+
+describe("buildYtDlpDownloadCmd — HLS sub-format fallback", () => {
+  const BASE_OPTIONS = {
+    ytDlpPath: "/bin/yt-dlp",
+    ffmpegLocation: "/bin",
+    sourceUrl: "https://cdn.example.com/video.mp4",
+    youtubeUrl: "https://www.youtube.com/watch?v=test123",
+    streamType: "video" as const,
+    useMpegTsOutput: false,
+    debug: false,
+    outputPath: "/tmp/test.mp4",
+  };
+
+  it("[REQ-042] should NOT pass '-f 301-0' when formatId is an HLS sub-format id", () => {
+    const cmd = buildYtDlpDownloadCmd({ ...BASE_OPTIONS, formatId: "301-0" });
+    // The format arg directly after -f must never be the raw HLS sub-format id
+    const fIndex = cmd.indexOf("-f");
+    expect(fIndex).toBeGreaterThan(-1);
+    const formatArg = cmd[fIndex + 1];
+    expect(formatArg).not.toBe("301-0");
+  });
+
+  it("[REQ-042] should use fallback format selector (not locked id) for HLS sub-format", () => {
+    const cmd = buildYtDlpDownloadCmd({ ...BASE_OPTIONS, formatId: "301-0" });
+    const fIndex = cmd.indexOf("-f");
+    const formatArg = cmd[fIndex + 1] ?? "";
+    // Fallback selector contains bv[vcodec^=avc1] for video
+    expect(formatArg).toContain("avc1");
+  });
+
+  it("[REQ-042] should still use locked format id for normal numeric format ids", () => {
+    const cmd = buildYtDlpDownloadCmd({ ...BASE_OPTIONS, formatId: "140" });
+    const fIndex = cmd.indexOf("-f");
+    const formatArg = cmd[fIndex + 1];
+    expect(formatArg).toBe("140");
+  });
+});
+
+// ---- buildYtDlpDownloadCmd — extended video fallback selector ----
+
+describe("buildYtDlpDownloadCmd — extended video fallback selector", () => {
+  const BASE_OPTIONS = {
+    ytDlpPath: "/bin/yt-dlp",
+    ffmpegLocation: "/bin",
+    sourceUrl: "https://www.youtube.com/watch?v=test123",
+    youtubeUrl: "https://www.youtube.com/watch?v=test123",
+    streamType: "video" as const,
+    useMpegTsOutput: false,
+    debug: false,
+    outputPath: "/tmp/test.mp4",
+  };
+
+  it("[REQ-042] should include vp09 in the fallback format selector for video", () => {
+    const cmd = buildYtDlpDownloadCmd({ ...BASE_OPTIONS }); // no formatId → always fallback
+    const fIndex = cmd.indexOf("-f");
+    const formatArg = cmd[fIndex + 1] ?? "";
+    expect(formatArg).toContain("vp09");
+  });
+
+  it("[REQ-042] should include av01 in the fallback format selector for video", () => {
+    const cmd = buildYtDlpDownloadCmd({ ...BASE_OPTIONS });
+    const fIndex = cmd.indexOf("-f");
+    const formatArg = cmd[fIndex + 1] ?? "";
+    expect(formatArg).toContain("av01");
+  });
+});
+
+// ---- parseYtDlpOutput — SABR manifest URLs and HLS sub-format IDs filtered ----
+
+describe("parseYtDlpOutput — SABR and HLS sub-format filtering", () => {
+  /** Minimal valid yt-dlp JSON with only SABR manifest URLs as formats */
+  const makeSabrOnlyJson = (): string =>
+    JSON.stringify({
+      title: "Test Video",
+      duration: 300,
+      thumbnail: "https://i.ytimg.com/vi/test/hqdefault.jpg",
+      webpage_url: "https://www.youtube.com/watch?v=test",
+      formats: [
+        {
+          format_id: "301-0",
+          vcodec: "avc1.4d401f",
+          acodec: "none",
+          height: 1080,
+          url: "https://manifest.googlevideo.com/api/manifest/hls_playlist/expire/123/id/test/itag/301/source/yt_live_broadcast/requiressl/yes/ratebypass/yes/hls_chunk_host/something.googlevideo.com/index.m3u8",
+        },
+        {
+          format_id: "140-0",
+          vcodec: "none",
+          acodec: "mp4a.40.2",
+          abr: 128,
+          url: "https://manifest.googlevideo.com/api/manifest/hls_playlist/expire/456/id/test/itag/140/source/yt_live_broadcast/requiressl/yes/ratebypass/yes/index.m3u8",
+        },
+      ],
+    });
+
+  it("[REQ-042] should return empty videoFormatId when all video formats are SABR manifest URLs", () => {
+    const result = parseYtDlpOutput(makeSabrOnlyJson());
+    expect(result.videoFormatId).toBe("");
+  });
+
+  it("[REQ-042] should return empty streamUrl when all video formats are SABR manifest URLs", () => {
+    const result = parseYtDlpOutput(makeSabrOnlyJson());
+    // streamUrl must not be a SABR manifest URL
+    expect(result.streamUrl).not.toContain("manifest.googlevideo.com");
+  });
+
+  /** Minimal valid yt-dlp JSON where all video formats have HLS sub-format ids */
+  const makeHlsSubIdOnlyJson = (): string =>
+    JSON.stringify({
+      title: "Test Video",
+      duration: 200,
+      thumbnail: "",
+      webpage_url: "https://www.youtube.com/watch?v=test2",
+      formats: [
+        {
+          format_id: "248-1",
+          vcodec: "avc1.640028",
+          acodec: "none",
+          height: 1080,
+          url: "https://rr1---sn-example.googlevideo.com/videoplayback?id=248",
+        },
+        {
+          format_id: "302-2",
+          vcodec: "avc1.4d401f",
+          acodec: "none",
+          height: 720,
+          url: "https://rr2---sn-example.googlevideo.com/videoplayback?id=302",
+        },
+      ],
+    });
+
+  it("[REQ-042] should return empty videoFormatId when all H.264 video formats have HLS sub-format ids", () => {
+    const result = parseYtDlpOutput(makeHlsSubIdOnlyJson());
+    expect(result.videoFormatId).toBe("");
+  });
+
+  it("[REQ-042] should return empty streamUrl when all H.264 video formats have HLS sub-format ids", () => {
+    const result = parseYtDlpOutput(makeHlsSubIdOnlyJson());
+    expect(result.streamUrl).toBe("");
+  });
+
+  /** Mix: one SABR format + one valid direct format */
+  const makeMixedJson = (): string =>
+    JSON.stringify({
+      title: "Mixed Video",
+      duration: 250,
+      thumbnail: "",
+      webpage_url: "https://www.youtube.com/watch?v=mixed",
+      formats: [
+        {
+          format_id: "137",
+          vcodec: "avc1.640028",
+          acodec: "none",
+          height: 1080,
+          url: "https://rr1---sn-example.googlevideo.com/videoplayback?itag=137",
+        },
+        {
+          format_id: "301-0",
+          vcodec: "avc1.4d401f",
+          acodec: "none",
+          height: 1080,
+          url: "https://manifest.googlevideo.com/api/manifest/hls_playlist/itag/301/index.m3u8",
+        },
+      ],
+    });
+
+  it("[REQ-042] should prefer valid direct format over SABR manifest URL in mixed formats", () => {
+    const result = parseYtDlpOutput(makeMixedJson());
+    expect(result.videoFormatId).toBe("137");
+    expect(result.streamUrl).toContain("videoplayback");
+  });
+});


### PR DESCRIPTION
## Summary

- **Root Cause:** YouTube forces SABR (Server-Adaptive Bitrate) streaming for avc1/H.264 formats on certain server IPs (live server kord.awaysome.de). All H.264 formats return `Requested format is not available` at download time, even though they appear valid in `--dump-json`.
- **Secondary cause:** HLS sub-format IDs (e.g. `301-0`, `248-1`) are session-specific and not portable across server IPs/sessions.

## Changes

| File | Change |
|------|--------|
| `src/stream/ffmpeg.ts` | `isHlsSubFormatId()` detects `301-0`-style IDs; HLS sub-IDs skip locked format path and go directly to fallback selector |
| `src/stream/ffmpeg.ts` | Extended video fallback chain: `avc1 → vp09 → av01 → bv[height<=1080] → bv` |
| `src/stream/yt-dlp.ts` | Filter SABR manifest URLs (`manifest.googlevideo.com`) and HLS sub-format IDs from format selection in `parseYtDlpOutput` |
| `docs/REQUIREMENTS.md` | Added REQ-042 with sub-requirements A-D |
| `docs/conclusions/` | Session conclusions with full root cause analysis |
| `tests/unit/sabr-format-fallback.test.ts` | 23 new tests, all green |

## Test plan

- [x] `bun test tests/unit/sabr-format-fallback.test.ts` — 23 tests green
- [x] `bun run build` — clean build
- [x] Local Docker deployment verified
- [ ] Test on live server kord.awaysome.de

🤖 Generated with [Claude Code](https://claude.com/claude-code)